### PR TITLE
fix missing dot in record

### DIFF
--- a/piratenpartei.ch.bind
+++ b/piratenpartei.ch.bind
@@ -10,7 +10,7 @@ id.piratenpartei.ch.		     	      600 IN A		78.46.227.180
 info.piratenpartei.ch.			      600 IN CNAME	traefik.piratenpartei.ch.
 jump.piratenpartei.ch.			      600 IN A		159.100.251.133
 members-crm.piratenpartei.ch.		      600 IN CNAME	traefik.piratenpartei.ch.
-my.piratenpartei.ch			      600 IN A		149.126.4.43
+my.piratenpartei.ch.			      600 IN A		149.126.4.43
 ns1.piratenpartei.ch.			      600 IN A		78.47.238.210 ; ns1.luadns.net (Germany)
 ns2.piratenpartei.ch.			      600 IN A		185.14.186.249 ; ns2.luadns.net (Netherlands)
 press-crm.piratenpartei.ch.		      600 IN CNAME	traefik.piratenpartei.ch.


### PR DESCRIPTION
the record for my.piratenpartei.ch misses a dot a the end.