### PR TITLE
Revert "Add missing SSHFP record for ed25519"

### DIFF
--- a/piratenpartei.ch.bind
+++ b/piratenpartei.ch.bind
@@ -103,10 +103,12 @@ mail                          600 IN A          149.126.4.43
 lists                         600 IN A          149.126.4.43
 
 ; jump host SSH fingerprint
+jump.piratenpartei.ch. IN SSHFP 1 1 e0c3f44fd115c5bfad665439fa7c03615608ccb9
 jump.piratenpartei.ch. IN SSHFP 1 2 785fd4ea1d4099601ae2c01519839464109c6f2794b6e59e1f28742244a9f60b
+jump.piratenpartei.ch. IN SSHFP 2 1 12848dd59b4689d96a512da2b6ab1250eb67127e
 jump.piratenpartei.ch. IN SSHFP 2 2 fc6fe7e0702a5f273c15e20df0dc335f380634ee1e041b71bedecb9ff3d83cde
+jump.piratenpartei.ch. IN SSHFP 3 1 839048ab99f33d6eff757b1cc7b6f5980fce36a5
 jump.piratenpartei.ch. IN SSHFP 3 2 ac8b2e701d5317063b6b8ee6ce4643ef0dd7690f3891ea2ed66d5d84436b8267
-jump.piratenpartei.ch. IN SSHFP 4 2 3feef501cafae38795c91306389df92bc2b81706d41f953a80ca42237f281159
 
 _github-challenge-ppschweiz.piratenpartei.ch.		600 IN TXT	"11aa7fb233"
 _github-challenge-ppschweiz.www.piratenpartei.ch.	600 IN TXT	"ee118dbb8c"


### PR DESCRIPTION
Reverts ppschweiz/domains#13
luadns doesn't build the zone because they doesn't support the SSHFP algorithm 4 (according to https://www.luadns.com/help.html#sshfp-record)