### PR TITLE
SPF Eintrag + no DMARC

### DIFF
--- a/piratenpartei.ch.bind
+++ b/piratenpartei.ch.bind
@@ -41,7 +41,7 @@ shop.piratenpartei.ch.				IN AAAA		2a01:ab20:0:4::43
 shop.piratenpartei.ch.				IN A		149.126.4.43
 traefik.piratenpartei.ch.			IN AAAA		2a04:c44:e00:33b4:46b:5cff:fe00:6fe
 traefik.piratenpartei.ch.			IN A		159.100.254.166
-traefik.piratenpartei.ch.			IN TXT		"v=spf1 a:coreos-5-p.piratenpartei.ch a mx include:spf.protection.cyon.net ?all"
+traefik.piratenpartei.ch.			IN TXT		"v=spf1 a:coreos-5-p.piratenpartei.ch a mx include:spf.protection.cyon.net ?all v=DMARC1; p=none"
 vvvote1.piratenpartei.ch.			IN A		78.46.227.182
 vvvote2.piratenpartei.ch.			IN A		78.46.227.182
 
@@ -50,6 +50,7 @@ talk.piratenpartei.ch.				IN CNAME	coreos-5-p.piratenpartei.ch.
 
 @						IN TXT		"v=spf1 a:coreos-5-p.piratenpartei.ch a mx include:spf.protection.cyon.net ?all"
 @						IN MX		10 s034.cyon.net.
+_dmarc 					IN TXT		"v=DMARC1; p=none"
 ag						IN MX		10 s034.cyon.net.
 ag						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
 ai						IN MX		10 s034.cyon.net.

--- a/piratenpartei.ch.bind
+++ b/piratenpartei.ch.bind
@@ -41,80 +41,80 @@ shop.piratenpartei.ch.				IN AAAA		2a01:ab20:0:4::43
 shop.piratenpartei.ch.				IN A		149.126.4.43
 traefik.piratenpartei.ch.			IN AAAA		2a04:c44:e00:33b4:46b:5cff:fe00:6fe
 traefik.piratenpartei.ch.			IN A		159.100.254.166
-traefik.piratenpartei.ch.			IN TXT		"v=spf1 a:coreos-5-p.piratenpartei.ch a mx include:spf.protection.cyon.net ?all v=DMARC1; p=none"
+traefik.piratenpartei.ch.			IN TXT		"v=spf1 a:coreos-5-p.piratenpartei.ch a mx include:spf.protection.cyon.net ~all"
 vvvote1.piratenpartei.ch.			IN A		78.46.227.182
 vvvote2.piratenpartei.ch.			IN A		78.46.227.182
 
 smtprelay.piratenpartei.ch.			IN CNAME	coreos-5-p.piratenpartei.ch.
 talk.piratenpartei.ch.				IN CNAME	coreos-5-p.piratenpartei.ch.
 
-@						IN TXT		"v=spf1 a:coreos-5-p.piratenpartei.ch a mx include:spf.protection.cyon.net ?all"
+@						IN TXT		"v=spf1 a:coreos-5-p.piratenpartei.ch a mx include:spf.protection.cyon.net ~all"
 @						IN MX		10 s034.cyon.net.
 _dmarc 					IN TXT		"v=DMARC1; p=none"
 ag						IN MX		10 s034.cyon.net.
-ag						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+ag						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 ai						IN MX		10 s034.cyon.net.
-ai						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+ai						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 ar						IN MX		10 s034.cyon.net.
-ar						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+ar						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 bb						IN MX		10 s034.cyon.net.
-bb						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+bb						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 be						IN MX		10 s034.cyon.net.
-be						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+be						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 bern.be 					IN MX		10 s034.cyon.net.
-bern.be						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+bern.be						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 bl						IN MX		10 s034.cyon.net.
-bl						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+bl						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 bs						IN MX		10 s034.cyon.net.
-bs						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+bs						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 fr						IN MX		10 s034.cyon.net.
-fr						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+fr						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 ge						IN MX		10 s034.cyon.net.
-ge						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+ge						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 gl						IN MX		10 s034.cyon.net.
-gl						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+gl						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 gr						IN MX		10 s034.cyon.net.
-gr						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+gr						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 ju						IN MX		10 s034.cyon.net.
-ju						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+ju						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 lu						IN MX		10 s034.cyon.net.
-lu						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+lu						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 ne						IN MX		10 s034.cyon.net.
-ne						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+ne						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 nw						IN MX		10 s034.cyon.net.
-nw						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+nw						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 ow						IN MX		10 s034.cyon.net.
-ow						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+ow						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 sg						IN MX		10 s034.cyon.net.
-sg						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+sg						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 sh						IN MX		10 s034.cyon.net.
-sh						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+sh						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 so						IN MX		10 s034.cyon.net.
-so						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+so						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 sz						IN MX		10 s034.cyon.net.
-sz						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+sz						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 tg						IN MX		10 s034.cyon.net.
-tg						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+tg						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 ti						IN MX		10 s034.cyon.net.
-ti						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+ti						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 ur						IN MX		10 s034.cyon.net.
-ur						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+ur						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 vd						IN MX		10 s034.cyon.net.
-vd						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+vd						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 vs						IN MX		10 s034.cyon.net.
-vs						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+vs						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 zg						IN MX		10 s034.cyon.net.
-zg						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+zg						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 zh						IN MX		10 s034.cyon.net.
-zh						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+zh						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 stadt.zh					IN MX		10 s034.cyon.net.
-stadt.zh					IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+stadt.zh					IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 winterthur.zh					IN MX		10 s034.cyon.net.
-winterthur.zh					IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+winterthur.zh					IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 zs						IN MX		10 s034.cyon.net.
-zs						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+zs						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 lists						IN MX		10 s034.cyon.net.
-lists						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ?all"
+lists						IN TXT		"v=spf1 a mx include:spf.protection.cyon.net ~all"
 
 @						IN AAAA		2a01:ab20:0:4::43
 www						IN AAAA		2a01:ab20:0:4::43


### PR DESCRIPTION
Ersetzte ?all (Neutral) durch ~all (Softfail)
und Ergänze um DMARC nicht vorhanden.

Siehe: https://www.mail-tester.com/test-k58ki0xi5&reloaded=2
https://de.wikipedia.org/wiki/Sender_Policy_Framework